### PR TITLE
Update appendix 00

### DIFF
--- a/2018-edition/src/appendix-00.md
+++ b/2018-edition/src/appendix-00.md
@@ -2,9 +2,6 @@
 
 The 2018 edition of the book is no longer distributed with Rust's documentation.
 
-If you came here via a link or web search, you may want to check out [the current
-version of the book](../appendix-00.html) instead.
+You may want to check out [the current
+version of the book](https://doc.rust-lang.org/1.30.0/book/2018-edition/appendix-00.html) instead.
 
-If you have an internet connection, you can [find a copy distributed with
-Rust
-1.30](https://doc.rust-lang.org/1.30.0/book/2018-edition/appendix-00.html).


### PR DESCRIPTION
The first link is broken leading to a 404 error, this might be more concise and less confusing as well.